### PR TITLE
GRF-546: Label type can be JSX.Element to allow addition of tag

### DIFF
--- a/src/components/IconCard/IconCard.tsx
+++ b/src/components/IconCard/IconCard.tsx
@@ -93,7 +93,7 @@ type IconCardProps = Override<
     /**
      * The title to display
      */
-    label: string;
+    label: string|JSX.Element;
 
     /**
      * The content to display


### PR DESCRIPTION
Label type of the IconCard component can be JSX.Element to allow addition of tag